### PR TITLE
Prevent images from linking back to original (archived) site

### DIFF
--- a/archive-discourse.py
+++ b/archive-discourse.py
@@ -154,29 +154,36 @@ def post_row(post_json):
         except TypeError:
             pass
 
-    img_tags = soup.findAll('img')
-    for img_tag in img_tags:
-        if 'src' in img_tag:
-            img_url = img_tag['src']
-            parsed_url = urlparse(img_url)
-            path = parsed_url.path
-            file_name = path.split('/')[-1]
-            if parsed_url.netloc and parsed_url.scheme:
-                pass
-            elif parsed_url.netloc:
-                img_url = base_scheme + ':' + img_url
-            else:
-                img_url = base_url + img_url
-            try:
-                response = requests.get(img_url, stream=True, cookies=jar)
-                img = Image.open(BytesIO(response.content))
-                img.save(os.getcwd() + '/images/' + file_name)
-                img_tag['src'] = '../../images/' + file_name
-            except Exception as err:
-                template = "An exception of type {0} occured. Arguments:\n{1!r}"
-                message = template.format(type(err).__name__, err.args)
-                print('post_row', 'save image', file_name, img_url, message)
-                img_tag['src'] = '../../images/missing_image.png'
+    links = soup.findAll('a')
+    for link in links:
+        img_tags = link.findAll('img')
+        for img_tag in img_tags:
+            if img_tag.has_attr('src'):
+                img_url = img_tag['src']
+                parsed_url = urlparse(img_url)
+                path = parsed_url.path
+                file_name = path.split('/')[-1]
+                if parsed_url.netloc and parsed_url.scheme:
+                    pass
+                elif parsed_url.netloc:
+                    img_url = base_scheme + ':' + img_url
+                else:
+                    img_url = base_url + img_url
+                try:
+                    response = requests.get(img_url, stream=True, cookies=jar)
+                    img = Image.open(BytesIO(response.content))
+                    img.save(os.getcwd() + '/images/' + file_name)
+                    img_tag['src'] = '../../images/' + file_name
+                    link['href'] = '../../images' + file_name
+                    # Below seemingly used for responsive image sizing in an actual Discourse site
+                    if img_tag.has_attr('srcset'):
+                        del img_tag['srcset']
+                except Exception as err:
+                    template = "An exception of type {0} occured. Arguments:\n{1!r}"
+                    message = template.format(type(err).__name__, err.args)
+                    # This is likely to throw out a lot of errors - do we care about them?
+                    print('post_row', 'save image', file_name, img_url, message)
+                    img_tag['src'] = '../../images/missing_image.png'
 
     content = ''
     for s in soup.contents:


### PR DESCRIPTION
Instead of looking for all images in a topic, look for links that _contain_ images. We will need to change up the href for those so as not to point back to the original site

Also strips out the `srcset` attribute of the images, as this seems unnessacery for an archive